### PR TITLE
Allow blank password

### DIFF
--- a/locallibs/kcpassword.py
+++ b/locallibs/kcpassword.py
@@ -27,7 +27,6 @@ def generate(passwd):
 
     for n in range(0, len(passwd), len(key)):
         ki = 0
-
         for j in range(n, min(n+len(key), len(passwd))):
             passwd[j] = passwd[j] ^ key[ki]
             ki += 1
@@ -36,6 +35,5 @@ def generate(passwd):
         passwd = [125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
     passwd = [chr(x) for x in passwd]
-
     return "".join(passwd)
 

--- a/locallibs/kcpassword.py
+++ b/locallibs/kcpassword.py
@@ -27,10 +27,15 @@ def generate(passwd):
 
     for n in range(0, len(passwd), len(key)):
         ki = 0
+
         for j in range(n, min(n+len(key), len(passwd))):
             passwd[j] = passwd[j] ^ key[ki]
             ki += 1
 
+    if (len(passwd) == 0):
+        passwd = [125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
     passwd = [chr(x) for x in passwd]
+
     return "".join(passwd)
 


### PR DESCRIPTION
This solves #20 

This addition makes it possible to create a user with a blank password. Just omit -p, --password option and just hit enter when asked to enter the password.

Not sure if there is a more elegant way, but it works and might help others that need this feature:-)

edit:
closing, as this was sloppy and also a bit confusing, because it has nothing to do with autologin...