### PR TITLE
Allow creating user with blank password

### DIFF
--- a/locallibs/kcpassword.py
+++ b/locallibs/kcpassword.py
@@ -31,6 +31,9 @@ def generate(passwd):
             passwd[j] = passwd[j] ^ key[ki]
             ki += 1
 
+    if (len(passwd) == 0):
+        passwd = [125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
     passwd = [chr(x) for x in passwd]
     return "".join(passwd)
 


### PR DESCRIPTION
(Apologies for the previous closed pull request)

This solves #20

This addition makes it possible to create a user with a blank password. Just omit -p, --password option and just hit enter when asked to enter the password.

Not sure if there is a more elegant way, but it works and might help others that need this feature...