### PR TITLE
Add two options --createhome and --key

### DIFF
--- a/createuserpkg
+++ b/createuserpkg
@@ -55,6 +55,10 @@ def main():
         help='User password. If this is not provided, interactively prompt for '
         'password.')
     optional_user_options.add_option(
+        '--key', '-k', default=False,
+        help='User ssh public key.  If provided stored in ~/.ssh/authorized_keys '
+        'implies --createhome and therefore works only when installing to "/". Optional.')
+    optional_user_options.add_option(
         '--fullname', '-f', help='User full name. Optional.')
     optional_user_options.add_option('--gid', '-g', help='User gid. Optional.')
     optional_user_options.add_option(
@@ -64,6 +68,10 @@ def main():
 
     optional_user_options.add_option(
         '--home', '-H', help='Path to user home directory. Optional.')
+    optional_user_options.add_option(
+        '--createhome', '-c', default=False,
+        action='store_true', help='Create the user home directory. '
+        'Works only when installing to "/". Optional.')
     optional_user_options.add_option(
         '--shell', '-s', help='User shell path. Optional.')
     optional_user_options.add_option(
@@ -133,7 +141,9 @@ def main():
     pkg_data = {'version': options.version,
                 'pkgid': options.identifier,
                 'destination_path': filename,
-                'user_plist': user_plist}
+                'user_plist': user_plist,
+                'createhome': options.createhome,
+                'key': options.key}
     if options.autologin:
         pkg_data['kcpassword'] = kcpassword.generate(password)
     if options.admin:

--- a/locallibs/userpkg.py
+++ b/locallibs/userpkg.py
@@ -37,12 +37,16 @@ def make_config_file(scripts_path, pkg_info):
     uuid = user_plist[u'generateduid'][0]
     user_is_admin = pkg_info.get('is_admin', False)
     enable_autologin = (pkg_info.get('kcpassword') != None)
+    createhome = pkg_info.get('createhome', False)
+    key = pkg_info.get('key', False)
     config_content = """
 USERNAME="%s"
 UUID=%s
 USER_IS_ADMIN=%s
 ENABLE_AUTOLOGIN=%s
-""" % (username, uuid, user_is_admin, enable_autologin)
+CREATEHOME=%s
+KEY="%s"
+""" % (username, uuid, user_is_admin, enable_autologin, createhome, key)
     config_path = os.path.join(scripts_path, "config")
     try:
         fileref = open(config_path, 'w')

--- a/pkg_scripts/postinstall
+++ b/pkg_scripts/postinstall
@@ -60,6 +60,18 @@ if [ "$3" == "/" ]; then
         # set AutoLogin preference, working around path issue with 'defaults'
         /usr/bin/defaults write "/Library/Preferences/com.apple.loginwindow" autoLoginUser "$USERNAME"
     fi
+    if [[ "$CREATEHOME" == "True" || "$KEY" != "False" ]]; then
+        # create home directory
+        /usr/sbin/createhomedir -c -u $USERNAME
+
+        if [[ "$KEY" != "False" ]]; then
+            # create authorized_keys file and populate...do this as the user to pick up home and gid
+            /usr/bin/sudo -u $USERNAME -H -s eval '/bin/mkdir -p ~/.ssh'
+            /usr/bin/sudo -u $USERNAME -H -s eval '/bin/chmod 700 ~/.ssh'
+            /usr/bin/sudo -u $USERNAME -H -s eval "/bin/echo '${KEY}' >> ~/.ssh/authorized_keys"
+            /usr/bin/sudo -u $USERNAME -H -s eval '/bin/chmod 600 ~/.ssh/authorized_keys'
+        fi
+    fi
 else
     # we're installing to non-boot volume; probably from Recovery-like or
     # AutoDMG environment - so we can just copy the user plist into place


### PR DESCRIPTION
`--createhome` creates the user's home directory and is largely based on the work and discussion in #14 

Changes for this option are to the `OptionParser` and creation of `pkg_data` in `createuserpkg`, `make_config_file` in `userpkg.py` and the `postinstall` script

The postinstall script now checks for this option and if found runs:

`/usr/sbin/createhomedir -c -u $USERNAME`

As discussed in the above pull request, apparently there is no way to use `createhomedir` when not installing to the boot volume, so this all occurs with the `if [ "$3" == "/" ]; then` block of the post install script

`--key` will add the provided public key to `~/.ssh/authorized_keys`.  Specifying `--key` implies `--createhome`.

Changes for this option are in the same locations as `--createhome`

The `postinstall` script will add the key to the user's `authorized_keys` file, creating it (and `~/.ssh`) if it doesn't exist.  It will also set permissions on the file/directory.  These commands are run as the created user in order to expand `~` and pick up the user's GID when the files are created.  This seems to require the use of `eval` which means you need to trust the content of the `--key` variable.  If there is a safer way to do this that would be a good change.