### PR TITLE
Replace uuid with uuidgen binutils

### DIFF
--- a/locallibs/userplist.py
+++ b/locallibs/userplist.py
@@ -14,7 +14,7 @@
 
 '''Generates our user account plist'''
 
-import uuid
+import subprocess
 
 
 class UserPlistException(Exception):
@@ -38,7 +38,7 @@ def generate(user_dict):
     user[u'home'] = [user_dict.get(u'home', u'/Users/%s' % user_dict[u'name'])]
     user[u'realname'] = [user_dict.get(u'realname', user_dict[u'name'])]
     user[u'shell'] = [user_dict.get(u'shell', u'/bin/bash')]
-    user[u'generateduid'] = [user_dict.get(u'uuid', str(uuid.uuid4()).upper())]
+    user[u'generateduid'] = [user_dict.get(u'uuid', str(subprocess.check_output("uuidgen", shell=True, universal_newlines=True).strip()).upper())]
     user[u'passwd'] = [u'********']
     user[u'authentication_authority'] = [
         ';ShadowHash;HASHLIST:<SALTED-SHA512-PBKDF2>']


### PR DESCRIPTION
Works on systems without `/dev/urandom`, for example, macOS recovery

![Screenshot_2021-03-24_22-50-01](https://user-images.githubusercontent.com/65906298/112393714-6edf4680-8cf3-11eb-8a0a-7c892a7db8b1.png)
