### PR TITLE
Decode full name and hint with UTF-8

### DIFF
--- a/createuserpkg
+++ b/createuserpkg
@@ -119,7 +119,7 @@ def main():
                  'uid': options.uid,
                  'ShadowHashData': shadowhash.generate(password)}
     if options.fullname:
-        user_data['realname'] = options.fullname
+        user_data['realname'] = options.fullname.decode("utf-8")
     if options.gid:
         user_data['gid'] = options.gid
     if options.generateduid:
@@ -131,7 +131,7 @@ def main():
     if options.hidden:
         user_data['IsHidden'] = u'YES'
     if options.hint:
-        user_data['hint'] = options.hint
+        user_data['hint'] = options.hint.decode("utf-8")
 
     user_plist = userplist.generate(user_data)
 


### PR DESCRIPTION
We had problems with German umlauts with user's full names when creating accounts using pycreateuserpkg. The changes made here have solved the problem for us and may be helpful for other users as well.

Since I have no real experience with UTF-8 support in Python 2.7 this may not be the ideal solution...